### PR TITLE
Add a Stop Button like the BeeBot Stop Button

### DIFF
--- a/src/BeeBot.py
+++ b/src/BeeBot.py
@@ -56,6 +56,9 @@ class BeeBot(pygame.sprite.Sprite):
 
         # Store MOVE_BEEBOT_* events here.
         self.memory = []
+        self.index = 0
+
+        self.running = False
 
     def move(self, event):
         """Move the BeeBot."""
@@ -77,11 +80,11 @@ class BeeBot(pygame.sprite.Sprite):
         self.memory.append(event)
 
     def push_out_memory(self):
-        """Act out the instructions in the BeeBot's "memory"."""
-        for instruction in self.memory:
-            # we use pygame's event queue because we need to check
-            # it regularly to prevent the game from crashing.
-            pygame.event.post(instruction)
+        """Act out one instruciton in the BeeBot's "memory"."""
+        # If memory is not empty
+        if self.memory != []:
+            pygame.event.post(self.memory[self.index])
+            self.index += 1
 
     def clear_memory(self):
         """Clear the BeeBot's "memory"."""

--- a/src/Button.py
+++ b/src/Button.py
@@ -30,7 +30,8 @@ class Button:
                  text_colour,  # The colour of the text/polygons (can be None)
                  background_colour,  # The colour of the text (can be None)
                  screen_location,  # The position on the screen
-                 size):  # The size of the Button
+                 size,  # The size of the Button
+                 displayed=True):  # Display Button if True
         """Create a Button."""
         self.text = text
         self.text_colour = text_colour
@@ -40,6 +41,7 @@ class Button:
         self.rect = pygame.Rect(screen_location, size)
         self.font = pygame.font.SysFont("comicsansms", 22)
         self.swapped = False  # Keeps track of wether a Button is swapped
+        self.displayed = displayed
 
         self.vertices = []
         if text == 'Forward':
@@ -72,27 +74,28 @@ class Button:
         return to_return
 
     def display(self, screen):
-        """Draw the Buttton object on screen, if it has a sprite."""
-        # Draw the Button background
-        screen.fill(self.background_colour, rect=self.rect)
+        """Draw the Buttton object on screen, if self.displayed is True."""
+        if self.displayed:
+            # Draw the Button background
+            screen.fill(self.background_colour, rect=self.rect)
 
-        # If list of vectors is empty
-        if self.vertices == []:
-            # Draw the Button text
-            text = self.font.render(self.text,
-                                    True,
-                                    self.text_colour)
+            # If list of vectors is empty
+            if self.vertices == []:
+                # Draw the Button text
+                text = self.font.render(self.text,
+                                        True,
+                                        self.text_colour)
 
-            # Center the background and text
-            text_rect = text.get_rect()
-            text_rect.centerx = self.rect.centerx
-            text_rect.centery = self.rect.centery
+                # Center the background and text
+                text_rect = text.get_rect()
+                text_rect.centerx = self.rect.centerx
+                text_rect.centery = self.rect.centery
 
-            # Render Button on screen
-            screen.blit(text, text_rect)
+                # Render Button on screen
+                screen.blit(text, text_rect)
 
-        else:
-            pygame.draw.polygon(screen, self.text_colour, self.vertices)
+            else:
+                pygame.draw.polygon(screen, self.text_colour, self.vertices)
 
     def swap_colours(self):
         """Swap the background and text / polygon colour of the Button."""
@@ -106,4 +109,6 @@ class Button:
         return (mouse_position[0] > self.rect.topleft[0] and
                 mouse_position[1] > self.rect.topleft[1] and
                 mouse_position[0] < self.rect.bottomright[0] and
-                mouse_position[1] < self.rect.bottomright[1])
+                mouse_position[1] < self.rect.bottomright[1] and
+                # Can't click on a Button that isn't displayed
+                self.displayed)

--- a/src/ButtonGroup.py
+++ b/src/ButtonGroup.py
@@ -17,6 +17,10 @@ class ButtonGroup:
         for _, button in self.buttons.items():
             button.display(screen)
 
+    def get_named_button(self, button_name):
+        """Return the named Button."""
+        return self.buttons[button_name]
+
     def get_pressed_button(self, mouse_position):
         """Return the pressed Button."""
         for _, button in self.buttons.items():

--- a/src/ButtonGroup.py
+++ b/src/ButtonGroup.py
@@ -17,7 +17,7 @@ class ButtonGroup:
         for _, button in self.buttons.items():
             button.display(screen)
 
-    def get_appropriate_button(self, mouse_position):
+    def get_pressed_button(self, mouse_position):
         """Return the pressed Button."""
         for _, button in self.buttons.items():
             if button.is_mouse_over_button(mouse_position):

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -246,7 +246,7 @@ class GameWindow(Thread):
             # assume it is a button press
             if event.type == pygame.MOUSEBUTTONUP and event.button == 1:
                 # If it was indeed a Button release
-                button = self.buttons.get_appropriate_button(event.pos)
+                button = self.buttons.get_pressed_button(event.pos)
                 if button is not None and button.swapped:
                     # Get the file corresponding to the Button pressed
                     button.swap_colours()
@@ -259,7 +259,7 @@ class GameWindow(Thread):
             # assume it is a button press
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 # If it was indeed a Button press
-                button = self.buttons.get_appropriate_button(event.pos)
+                button = self.buttons.get_pressed_button(event.pos)
                 if button is not None:
                     # Mark that Button as being pressed
                     button.swap_colours()
@@ -537,7 +537,7 @@ class GameWindow(Thread):
             # If the event is a left mouse button up
             # assume it is a button press
             if event.type == pygame.MOUSEBUTTONUP and event.button == 1:
-                button = self.buttons.get_appropriate_button(event.pos)
+                button = self.buttons.get_pressed_button(event.pos)
                 if button is not None and button.swapped:
                     button.swap_colours()
                     self.handle_button_press(button)
@@ -545,7 +545,7 @@ class GameWindow(Thread):
                     self.buttons.unswap_all()
 
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
-                button = self.buttons.get_appropriate_button(event.pos)
+                button = self.buttons.get_pressed_button(event.pos)
                 if button is not None:
                     button.swap_colours()
 

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -526,19 +526,6 @@ class GameWindow(Thread):
                 # End the loop
                 self._logic_running = False
 
-            elif event.type == pygame.KEYDOWN:
-                self.handle_key_press(event)
-
-            # If the event is a movement event
-            # Move the BeeBot.
-            elif (event.type >= CustomEvent.MOVE_BEEBOT_UP and
-                  event.type <= CustomEvent.MOVE_BEEBOT_RIGHT):
-
-                self.robot.move(event)
-                self.check_for_obstacle_collisions()
-                self.check_for_goal_collisions()
-                self.check_for_off_map()
-
             # If the event is a left mouse button up
             # assume it is a button press
             elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
@@ -553,6 +540,19 @@ class GameWindow(Thread):
                 button = self.buttons.get_pressed_button(event.pos)
                 if button is not None:
                     button.swap_colours()
+
+            elif event.type == pygame.KEYDOWN:
+                self.handle_key_press(event)
+
+            # If the event is a movement event
+            # Move the BeeBot.
+            elif (event.type >= CustomEvent.MOVE_BEEBOT_UP and
+                  event.type <= CustomEvent.MOVE_BEEBOT_RIGHT):
+
+                self.robot.move(event)
+                self.check_for_obstacle_collisions()
+                self.check_for_goal_collisions()
+                self.check_for_off_map()
 
             elif self.robot.running:
                 self.robot.push_out_memory()

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -555,12 +555,13 @@ class GameWindow(Thread):
                 self.check_for_off_map()
 
             elif self.robot.running:
-                self.robot.push_out_memory()
-
-                # If there are no more instructions in the BeeBot's memory
+                # If there are no further instructions in the BeeBot's memory
                 if len(self.robot.memory) == self.robot.index:
                     # Stop the BeeBot
                     self.stop_beebot_movement()
+                else:
+                    # Push out the next instruction
+                    self.robot.push_out_memory()
 
         # If we get here, the main game loop has exited sommehow
         # Let's exit safely

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -599,6 +599,19 @@ class GameWindow(Thread):
             self.buttons.get_named_button('Go').displayed = False
             self.buttons.get_named_button('Stop').displayed = True
 
+            # Hide 'Reset' and 'Clear' Buttons to prevent them
+            # being pressed mid run as this can cause odd
+            # behaviour where a reset BeeBot continues to movement
+            # or a running BeeBot has no instructions to run.
+            self.buttons.get_named_button('Reset').displayed = False
+            self.buttons.get_named_button('Clear').displayed = False
+
+            # Prevent the BeeBot being 'programmed' while running
+            self.buttons.get_named_button('Forward').displayed = False
+            self.buttons.get_named_button('Turn Left').displayed = False
+            self.buttons.get_named_button('Backward').displayed = False
+            self.buttons.get_named_button('Turn Right').displayed = False
+
     def stop_beebot_movement(self):
         """Stop the BeeBot moving and turn the Stop Buton to the Go Button."""
         if self.robot.running:
@@ -612,6 +625,17 @@ class GameWindow(Thread):
 
             self.buttons.get_named_button('Go').displayed = True
             self.buttons.get_named_button('Stop').displayed = False
+
+            # Now that movement has stopped, these Buttons cannot cause
+            # odd side effects any more, so display them once again.
+            self.buttons.get_named_button('Reset').displayed = True
+            self.buttons.get_named_button('Clear').displayed = True
+
+            # Allow the BeeBot to be programmed again.
+            self.buttons.get_named_button('Forward').displayed = True
+            self.buttons.get_named_button('Turn Left').displayed = True
+            self.buttons.get_named_button('Backward').displayed = True
+            self.buttons.get_named_button('Turn Right').displayed = True
 
     def fail_run(self):
         """Clear the event queue and push a RUN_FAIL event."""

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -508,7 +508,7 @@ class GameWindow(Thread):
                 pygame.quit()
                 sys.exit()
 
-            if event.type == CustomEvent.RUN_FAIL:
+            elif event.type == CustomEvent.RUN_FAIL:
                 self.robot.crash()
                 sleep(1)
                 self.rendering_mode = RenderingMode.FAIL_SCREEN
@@ -520,8 +520,7 @@ class GameWindow(Thread):
 
                 self.robot.index = 0
                 self.flip(False)
-
-            if event.type == CustomEvent.RUN_WIN:
+            elif event.type == CustomEvent.RUN_WIN:
                 sleep(1)
                 self.rendering_mode = RenderingMode.WIN_SCREEN
                 sleep(2)
@@ -531,12 +530,12 @@ class GameWindow(Thread):
                 # End the loop
                 self._logic_running = False
 
-            if event.type == pygame.KEYDOWN:
+            elif event.type == pygame.KEYDOWN:
                 self.handle_key_press(event)
 
             # If the event is a left mouse button up
             # assume it is a button press
-            if event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
                 button = self.buttons.get_pressed_button(event.pos)
                 if button is not None and button.swapped:
                     button.swap_colours()
@@ -544,14 +543,14 @@ class GameWindow(Thread):
                 else:
                     self.buttons.unswap_all()
 
-            if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 button = self.buttons.get_pressed_button(event.pos)
                 if button is not None:
                     button.swap_colours()
 
             # If no event and self.robot.memory has not been cleared
             # move the robot
-            if self.robot.running:
+            elif self.robot.running:
                 self.robot.push_out_memory()
                 event = pygame.event.poll()
 

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -305,7 +305,7 @@ class GameWindow(Thread):
 
         buttons_on_the_left = True
 
-        self.create_buttons(buttons_on_the_left, False)
+        self.create_buttons(buttons_on_the_left)
 
         if buttons_on_the_left:
             self.size = (self.width + 400, self.height)
@@ -318,160 +318,157 @@ class GameWindow(Thread):
         if self._rendering_running:
             self.screen = pygame.display.set_mode(self.size)
 
-    def create_buttons(self, buttons_on_the_left, running):
+    def create_buttons(self, buttons_on_the_left):
         """Helper method to populate ButtonGroup."""
         # Empty ButtonGroup
         self.buttons.removal_all()
 
-        if running:
-            if buttons_on_the_left:
-                stop_button = Button('STOP',
+        if buttons_on_the_left:
+            forward_button = Button('Forward',
+                                    GameWindow.BLACK,
+                                    GameWindow.WHITE,
+                                    (self.width + 140,
+                                     float(self.height)/2 - 240),
+                                    (120, 120))
+
+            self.buttons.add(forward_button)
+
+            backward_button = Button('Backward',
+                                     GameWindow.BLACK,
                                      GameWindow.WHITE,
-                                     GameWindow.RED,
                                      (self.width + 140,
-                                      float(self.height)/2 - 110),
+                                      float(self.height)/2 + 20),
                                      (120, 120))
 
-                self.buttons.add(stop_button)
+            self.buttons.add(backward_button)
 
-            else:
-                go_button = Button('STOP',
-                                   GameWindow.WHITE,
-                                   GameWindow.RED,
-                                   (float(self.width)/2 - 60,
-                                    self.height + 140),
-                                   (120, 120))
-
-                self.buttons.add(go_button)
-
-        else:
-            if buttons_on_the_left:
-                forward_button = Button('Forward',
-                                        GameWindow.BLACK,
-                                        GameWindow.WHITE,
-                                        (self.width + 140,
-                                         float(self.height)/2 - 240),
-                                        (120, 120))
-
-                self.buttons.add(forward_button)
-
-                backward_button = Button('Backward',
-                                         GameWindow.BLACK,
-                                         GameWindow.WHITE,
-                                         (self.width + 140,
-                                          float(self.height)/2 + 20),
-                                         (120, 120))
-
-                self.buttons.add(backward_button)
-
-                turn_left_button = Button('Turn Left',
-                                          GameWindow.BLACK,
-                                          GameWindow.WHITE,
-                                          (self.width + 10,
-                                           float(self.height)/2 - 110),
-                                          (120, 120))
-
-                self.buttons.add(turn_left_button)
-
-                turn_right_button = Button('Turn Right',
-                                           GameWindow.BLACK,
-                                           GameWindow.WHITE,
-                                           (self.width + 270,
-                                            float(self.height)/2 - 110),
-                                           (120, 120))
-
-                self.buttons.add(turn_right_button)
-
-                go_button = Button('Go',
-                                   GameWindow.BLACK,
-                                   GameWindow.WHITE,
-                                   (self.width + 140,
-                                    float(self.height)/2 - 110),
-                                   (120, 120))
-
-                self.buttons.add(go_button)
-
-                reset_button = Button('Reset',
+            turn_left_button = Button('Turn Left',
                                       GameWindow.BLACK,
                                       GameWindow.WHITE,
                                       (self.width + 10,
-                                       float(self.height)/2 + 20),
+                                       float(self.height)/2 - 110),
                                       (120, 120))
 
-                self.buttons.add(reset_button)
+            self.buttons.add(turn_left_button)
 
-                clear_button = Button('Clear',
-                                      GameWindow.BLACK,
-                                      GameWindow.WHITE,
-                                      (self.width + 270,
-                                       float(self.height)/2 + 20),
-                                      (120, 120))
+            turn_right_button = Button('Turn Right',
+                                       GameWindow.BLACK,
+                                       GameWindow.WHITE,
+                                       (self.width + 270,
+                                        float(self.height)/2 - 110),
+                                       (120, 120))
 
-                self.buttons.add(clear_button)
+            self.buttons.add(turn_right_button)
 
-            else:
-                forward_button = Button('Forward',
-                                        GameWindow.BLACK,
-                                        GameWindow.WHITE,
-                                        (float(self.width)/2 - 60,
-                                         self.height + 10),
-                                        (120, 120))
+            go_button = Button('Go',
+                               GameWindow.BLACK,
+                               GameWindow.WHITE,
+                               (self.width + 140,
+                                float(self.height)/2 - 110),
+                               (120, 120))
 
-                self.buttons.add(forward_button)
+            self.buttons.add(go_button)
 
-                backward_button = Button('Backward',
-                                         GameWindow.BLACK,
-                                         GameWindow.WHITE,
-                                         (float(self.width)/2 - 60,
-                                          self.height + 270),
-                                         (120, 120))
+            stop_button = Button('Stop',
+                                 GameWindow.WHITE,
+                                 GameWindow.RED,
+                                 (self.width + 140,
+                                  float(self.height)/2 - 110),
+                                 (120, 120),
+                                 False)
 
-                self.buttons.add(backward_button)
+            self.buttons.add(stop_button)
 
-                turn_left_button = Button('Turn Left',
-                                          GameWindow.BLACK,
-                                          GameWindow.WHITE,
-                                          (float(self.width)/2 - 190,
-                                           self.height + 140),
-                                          (120, 120))
+            reset_button = Button('Reset',
+                                  GameWindow.BLACK,
+                                  GameWindow.WHITE,
+                                  (self.width + 10,
+                                   float(self.height)/2 + 20),
+                                  (120, 120))
 
-                self.buttons.add(turn_left_button)
+            self.buttons.add(reset_button)
 
-                turn_right_button = Button('Turn Right',
-                                           GameWindow.BLACK,
-                                           GameWindow.WHITE,
-                                           (float(self.width)/2 + 70,
-                                            self.height + 140),
-                                           (120, 120))
+            clear_button = Button('Clear',
+                                  GameWindow.BLACK,
+                                  GameWindow.WHITE,
+                                  (self.width + 270,
+                                   float(self.height)/2 + 20),
+                                  (120, 120))
 
-                self.buttons.add(turn_right_button)
+            self.buttons.add(clear_button)
 
-                go_button = Button('Go',
-                                   GameWindow.BLACK,
-                                   GameWindow.WHITE,
-                                   (float(self.width)/2 - 60,
-                                    self.height + 140),
-                                   (120, 120))
+        else:
+            forward_button = Button('Forward',
+                                    GameWindow.BLACK,
+                                    GameWindow.WHITE,
+                                    (float(self.width)/2 - 60,
+                                     self.height + 10),
+                                    (120, 120))
 
-                self.buttons.add(go_button)
+            self.buttons.add(forward_button)
 
-                reset_button = Button('Reset',
+            backward_button = Button('Backward',
+                                     GameWindow.BLACK,
+                                     GameWindow.WHITE,
+                                     (float(self.width)/2 - 60,
+                                      self.height + 270),
+                                     (120, 120))
+
+            self.buttons.add(backward_button)
+
+            turn_left_button = Button('Turn Left',
                                       GameWindow.BLACK,
                                       GameWindow.WHITE,
                                       (float(self.width)/2 - 190,
-                                       self.height + 270),
+                                       self.height + 140),
                                       (120, 120))
 
-                self.buttons.add(reset_button)
+            self.buttons.add(turn_left_button)
 
-                clear_button = Button('Clear',
-                                      GameWindow.BLACK,
-                                      GameWindow.WHITE,
-                                      (float(self.width)/2 + 70,
-                                       self.height + 270),
-                                      (120, 120))
+            turn_right_button = Button('Turn Right',
+                                       GameWindow.BLACK,
+                                       GameWindow.WHITE,
+                                       (float(self.width)/2 + 70,
+                                        self.height + 140),
+                                       (120, 120))
 
-                self.buttons.add(clear_button)
+            self.buttons.add(turn_right_button)
+
+            go_button = Button('Go',
+                               GameWindow.BLACK,
+                               GameWindow.WHITE,
+                               (float(self.width)/2 - 60, self.height + 140),
+                               (120, 120))
+
+            self.buttons.add(go_button)
+
+            stop_button = Button('Stop',
+                                 GameWindow.WHITE,
+                                 GameWindow.RED,
+                                 (float(self.width)/2 - 60,
+                                  self.height + 140),
+                                 (120, 120),
+                                 False)
+
+            self.buttons.add(stop_button)
+
+            reset_button = Button('Reset',
+                                  GameWindow.BLACK,
+                                  GameWindow.WHITE,
+                                  (float(self.width)/2 - 190,
+                                   self.height + 270),
+                                  (120, 120))
+
+            self.buttons.add(reset_button)
+
+            clear_button = Button('Clear',
+                                  GameWindow.BLACK,
+                                  GameWindow.WHITE,
+                                  (float(self.width)/2 + 70,
+                                   self.height + 270),
+                                  (120, 120))
+
+            self.buttons.add(clear_button)
 
     def start_logic(self, scenario=None):
         """
@@ -514,12 +511,11 @@ class GameWindow(Thread):
                 self.rendering_mode = RenderingMode.FAIL_SCREEN
                 sleep(2)
                 self.rendering_mode = RenderingMode.NORMAL
+                self.stop_beebot_movement()
                 self.robot.reset_position()
                 self.robot.clear_memory()
                 self.board.goal_group.reset_all_goals()
 
-                self.robot.index = 0
-                self.flip(False)
             elif event.type == CustomEvent.RUN_WIN:
                 sleep(1)
                 self.rendering_mode = RenderingMode.WIN_SCREEN
@@ -532,6 +528,16 @@ class GameWindow(Thread):
 
             elif event.type == pygame.KEYDOWN:
                 self.handle_key_press(event)
+
+            # If the event is a movement event
+            # Move the BeeBot.
+            elif (event.type >= CustomEvent.MOVE_BEEBOT_UP and
+                  event.type <= CustomEvent.MOVE_BEEBOT_RIGHT):
+
+                self.robot.move(event)
+                self.check_for_obstacle_collisions()
+                self.check_for_goal_collisions()
+                self.check_for_off_map()
 
             # If the event is a left mouse button up
             # assume it is a button press
@@ -548,23 +554,13 @@ class GameWindow(Thread):
                 if button is not None:
                     button.swap_colours()
 
-            # If no event and self.robot.memory has not been cleared
-            # move the robot
             elif self.robot.running:
                 self.robot.push_out_memory()
-                event = pygame.event.poll()
 
-                # Flip state to input if no more instructions to be done
+                # If there are no more instructions in the BeeBot's memory
                 if len(self.robot.memory) == self.robot.index:
-                    # Reset current instruction index
-                    self.robot.index = 0
-                    # Flip to input
-                    self.flip(False)
-
-                self.robot.move(event)
-                self.check_for_obstacle_collisions()
-                self.check_for_goal_collisions()
-                self.check_for_off_map()
+                    # Stop the BeeBot
+                    self.stop_beebot_movement()
 
         # If we get here, the main game loop has exited sommehow
         # Let's exit safely
@@ -594,10 +590,21 @@ class GameWindow(Thread):
             # push a win event
             pygame.event.post(pygame.event.Event(CustomEvent.RUN_WIN))
 
-    def flip(self, bool):
-        """Change the state of robot and buttons."""
-        self.robot.running = bool
-        self.create_buttons(True, bool)
+    def start_beebot_movement(self):
+        """Start the BeeBot moving and turn the Go Buton to the Stop Button."""
+        self.robot.running = True
+
+        self.buttons.get_named_button('Go').displayed = False
+        self.buttons.get_named_button('Stop').displayed = True
+
+    def stop_beebot_movement(self):
+        """Stop the BeeBot moving and turn the Stop Buton to the Go Button."""
+        self.robot.running = False
+        # Reset the BeeBot memory pointer to the start of the instructions
+        self.robot.index = 0
+
+        self.buttons.get_named_button('Go').displayed = True
+        self.buttons.get_named_button('Stop').displayed = False
 
     def fail_run(self):
         """Clear the event queue and push a RUN_FAIL event."""
@@ -605,8 +612,6 @@ class GameWindow(Thread):
         pygame.event.clear()
         # push a fail event
         pygame.event.post(pygame.event.Event(CustomEvent.RUN_FAIL))
-        # Flip state to input
-        self.flip(False)
 
     def check_for_obstacle_collisions(self):
         """Check if the BeeBot is currently on a Obstacle."""
@@ -659,7 +664,6 @@ class GameWindow(Thread):
 
     def handle_button_press(self, button):
         """Convert button press into game logic."""
-
         if button.text == 'Forward':
             self.store_movement('Forward')
 
@@ -682,14 +686,10 @@ class GameWindow(Thread):
             self.robot.memory = []
 
         if button.text == 'Go':
-            # Flip state to running
-            self.flip(True)
+            self.start_beebot_movement()
 
-        if button.text == 'STOP':
-            # Reset current instruction index
-            self.robot.index = 0
-            # Flip state to input
-            self.flip(False)
+        if button.text == 'Stop':
+            self.stop_beebot_movement()
 
     def handle_key_press(self, event):
         """Convert key press into game logic."""
@@ -717,8 +717,6 @@ class GameWindow(Thread):
         if event.key == ord('x') or event.key == ord('X'):
             self.robot.memory = []
 
-        # if the event is the G key, push stored movement
-        # events into the event queue.
+        # if the event is the G key, start the BeeBot.
         if event.key == ord('g') or event.key == ord('G'):
-            # Flip state to running
-            self.flip(True)
+            self.start_beebot_movement()

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -592,23 +592,25 @@ class GameWindow(Thread):
 
     def start_beebot_movement(self):
         """Start the BeeBot moving and turn the Go Buton to the Stop Button."""
-        self.robot.running = True
+        if not self.robot.running:
+            self.robot.running = True
 
-        self.buttons.get_named_button('Go').displayed = False
-        self.buttons.get_named_button('Stop').displayed = True
+            self.buttons.get_named_button('Go').displayed = False
+            self.buttons.get_named_button('Stop').displayed = True
 
     def stop_beebot_movement(self):
         """Stop the BeeBot moving and turn the Stop Buton to the Go Button."""
-        self.robot.running = False
-        # Reset the BeeBot memory pointer to the start of the instructions
-        self.robot.index = 0
+        if self.robot.running:
+            self.robot.running = False
+            # Reset the BeeBot memory pointer to the start of the instructions
+            self.robot.index = 0
 
-        # Clear the queue incase movement events have already
-        # been pushed to the queue.
-        pygame.event.clear()
+            # Clear the queue incase movement events have already
+            # been pushed to the queue.
+            pygame.event.clear()
 
-        self.buttons.get_named_button('Go').displayed = True
-        self.buttons.get_named_button('Stop').displayed = False
+            self.buttons.get_named_button('Go').displayed = True
+            self.buttons.get_named_button('Stop').displayed = False
 
     def fail_run(self):
         """Clear the event queue and push a RUN_FAIL event."""

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -720,3 +720,7 @@ class GameWindow(Thread):
         # if the event is the G key, start the BeeBot.
         if event.key == ord('g') or event.key == ord('G'):
             self.start_beebot_movement()
+
+        # if the event is the S key, stop the BeeBot.
+        if event.key == ord('s') or event.key == ord('S'):
+            self.stop_beebot_movement()

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -305,7 +305,7 @@ class GameWindow(Thread):
 
         buttons_on_the_left = True
 
-        self.create_buttons(buttons_on_the_left)
+        self.create_buttons(buttons_on_the_left, False)
 
         if buttons_on_the_left:
             self.size = (self.width + 400, self.height)
@@ -318,137 +318,160 @@ class GameWindow(Thread):
         if self._rendering_running:
             self.screen = pygame.display.set_mode(self.size)
 
-    def create_buttons(self, buttons_on_the_left):
+    def create_buttons(self, buttons_on_the_left, running):
         """Helper method to populate ButtonGroup."""
         # Empty ButtonGroup
         self.buttons.removal_all()
 
-        if buttons_on_the_left:
-            forward_button = Button('Forward',
-                                    GameWindow.BLACK,
-                                    GameWindow.WHITE,
-                                    (self.width + 140,
-                                     float(self.height)/2 - 240),
-                                    (120, 120))
-
-            self.buttons.add(forward_button)
-
-            backward_button = Button('Backward',
-                                     GameWindow.BLACK,
+        if running:
+            if buttons_on_the_left:
+                stop_button = Button('STOP',
                                      GameWindow.WHITE,
+                                     GameWindow.RED,
                                      (self.width + 140,
-                                      float(self.height)/2 + 20),
+                                      float(self.height)/2 - 110),
                                      (120, 120))
 
-            self.buttons.add(backward_button)
+                self.buttons.add(stop_button)
 
-            turn_left_button = Button('Turn Left',
+            else:
+                go_button = Button('STOP',
+                                   GameWindow.WHITE,
+                                   GameWindow.RED,
+                                   (float(self.width)/2 - 60,
+                                    self.height + 140),
+                                   (120, 120))
+
+                self.buttons.add(go_button)
+
+        else:
+            if buttons_on_the_left:
+                forward_button = Button('Forward',
+                                        GameWindow.BLACK,
+                                        GameWindow.WHITE,
+                                        (self.width + 140,
+                                         float(self.height)/2 - 240),
+                                        (120, 120))
+
+                self.buttons.add(forward_button)
+
+                backward_button = Button('Backward',
+                                         GameWindow.BLACK,
+                                         GameWindow.WHITE,
+                                         (self.width + 140,
+                                          float(self.height)/2 + 20),
+                                         (120, 120))
+
+                self.buttons.add(backward_button)
+
+                turn_left_button = Button('Turn Left',
+                                          GameWindow.BLACK,
+                                          GameWindow.WHITE,
+                                          (self.width + 10,
+                                           float(self.height)/2 - 110),
+                                          (120, 120))
+
+                self.buttons.add(turn_left_button)
+
+                turn_right_button = Button('Turn Right',
+                                           GameWindow.BLACK,
+                                           GameWindow.WHITE,
+                                           (self.width + 270,
+                                            float(self.height)/2 - 110),
+                                           (120, 120))
+
+                self.buttons.add(turn_right_button)
+
+                go_button = Button('Go',
+                                   GameWindow.BLACK,
+                                   GameWindow.WHITE,
+                                   (self.width + 140,
+                                    float(self.height)/2 - 110),
+                                   (120, 120))
+
+                self.buttons.add(go_button)
+
+                reset_button = Button('Reset',
                                       GameWindow.BLACK,
                                       GameWindow.WHITE,
                                       (self.width + 10,
-                                       float(self.height)/2 - 110),
+                                       float(self.height)/2 + 20),
                                       (120, 120))
 
-            self.buttons.add(turn_left_button)
+                self.buttons.add(reset_button)
 
-            turn_right_button = Button('Turn Right',
-                                       GameWindow.BLACK,
-                                       GameWindow.WHITE,
-                                       (self.width + 270,
-                                        float(self.height)/2 - 110),
-                                       (120, 120))
+                clear_button = Button('Clear',
+                                      GameWindow.BLACK,
+                                      GameWindow.WHITE,
+                                      (self.width + 270,
+                                       float(self.height)/2 + 20),
+                                      (120, 120))
 
-            self.buttons.add(turn_right_button)
+                self.buttons.add(clear_button)
 
-            go_button = Button('Go',
-                               GameWindow.BLACK,
-                               GameWindow.WHITE,
-                               (self.width + 140,
-                                float(self.height)/2 - 110),
-                               (120, 120))
+            else:
+                forward_button = Button('Forward',
+                                        GameWindow.BLACK,
+                                        GameWindow.WHITE,
+                                        (float(self.width)/2 - 60,
+                                         self.height + 10),
+                                        (120, 120))
 
-            self.buttons.add(go_button)
+                self.buttons.add(forward_button)
 
-            reset_button = Button('Reset',
-                                  GameWindow.BLACK,
-                                  GameWindow.WHITE,
-                                  (self.width + 10,
-                                   float(self.height)/2 + 20),
-                                  (120, 120))
+                backward_button = Button('Backward',
+                                         GameWindow.BLACK,
+                                         GameWindow.WHITE,
+                                         (float(self.width)/2 - 60,
+                                          self.height + 270),
+                                         (120, 120))
 
-            self.buttons.add(reset_button)
+                self.buttons.add(backward_button)
 
-            clear_button = Button('Clear',
-                                  GameWindow.BLACK,
-                                  GameWindow.WHITE,
-                                  (self.width + 270,
-                                   float(self.height)/2 + 20),
-                                  (120, 120))
+                turn_left_button = Button('Turn Left',
+                                          GameWindow.BLACK,
+                                          GameWindow.WHITE,
+                                          (float(self.width)/2 - 190,
+                                           self.height + 140),
+                                          (120, 120))
 
-            self.buttons.add(clear_button)
+                self.buttons.add(turn_left_button)
 
-        else:
-            forward_button = Button('Forward',
-                                    GameWindow.BLACK,
-                                    GameWindow.WHITE,
-                                    (float(self.width)/2 - 60,
-                                     self.height + 10),
-                                    (120, 120))
+                turn_right_button = Button('Turn Right',
+                                           GameWindow.BLACK,
+                                           GameWindow.WHITE,
+                                           (float(self.width)/2 + 70,
+                                            self.height + 140),
+                                           (120, 120))
 
-            self.buttons.add(forward_button)
+                self.buttons.add(turn_right_button)
 
-            backward_button = Button('Backward',
-                                     GameWindow.BLACK,
-                                     GameWindow.WHITE,
-                                     (float(self.width)/2 - 60,
-                                      self.height + 270),
-                                     (120, 120))
+                go_button = Button('Go',
+                                   GameWindow.BLACK,
+                                   GameWindow.WHITE,
+                                   (float(self.width)/2 - 60,
+                                    self.height + 140),
+                                   (120, 120))
 
-            self.buttons.add(backward_button)
+                self.buttons.add(go_button)
 
-            turn_left_button = Button('Turn Left',
+                reset_button = Button('Reset',
                                       GameWindow.BLACK,
                                       GameWindow.WHITE,
                                       (float(self.width)/2 - 190,
-                                       self.height + 140),
+                                       self.height + 270),
                                       (120, 120))
 
-            self.buttons.add(turn_left_button)
+                self.buttons.add(reset_button)
 
-            turn_right_button = Button('Turn Right',
-                                       GameWindow.BLACK,
-                                       GameWindow.WHITE,
-                                       (float(self.width)/2 + 70,
-                                        self.height + 140),
-                                       (120, 120))
+                clear_button = Button('Clear',
+                                      GameWindow.BLACK,
+                                      GameWindow.WHITE,
+                                      (float(self.width)/2 + 70,
+                                       self.height + 270),
+                                      (120, 120))
 
-            self.buttons.add(turn_right_button)
-
-            go_button = Button('Go',
-                               GameWindow.BLACK,
-                               GameWindow.WHITE,
-                               (float(self.width)/2 - 60, self.height + 140),
-                               (120, 120))
-
-            self.buttons.add(go_button)
-
-            reset_button = Button('Reset',
-                                  GameWindow.BLACK,
-                                  GameWindow.WHITE,
-                                  (float(self.width)/2 - 190,
-                                   self.height + 270),
-                                  (120, 120))
-
-            self.buttons.add(reset_button)
-
-            clear_button = Button('Clear',
-                                  GameWindow.BLACK,
-                                  GameWindow.WHITE,
-                                  (float(self.width)/2 + 70,
-                                   self.height + 270),
-                                  (120, 120))
-
-            self.buttons.add(clear_button)
+                self.buttons.add(clear_button)
 
     def start_logic(self, scenario=None):
         """
@@ -495,6 +518,9 @@ class GameWindow(Thread):
                 self.robot.clear_memory()
                 self.board.goal_group.reset_all_goals()
 
+                self.robot.index = 0
+                self.flip(False)
+
             if event.type == CustomEvent.RUN_WIN:
                 sleep(1)
                 self.rendering_mode = RenderingMode.WIN_SCREEN
@@ -507,15 +533,6 @@ class GameWindow(Thread):
 
             if event.type == pygame.KEYDOWN:
                 self.handle_key_press(event)
-
-            # If the event is a movement event
-            # Move the BeeBot.
-            if (event.type >= CustomEvent.MOVE_BEEBOT_UP and
-               event.type <= CustomEvent.MOVE_BEEBOT_RIGHT):
-                self.robot.move(event)
-                self.check_for_obstacle_collisions()
-                self.check_for_goal_collisions()
-                self.check_for_off_map()
 
             # If the event is a left mouse button up
             # assume it is a button press
@@ -531,6 +548,24 @@ class GameWindow(Thread):
                 button = self.buttons.get_appropriate_button(event.pos)
                 if button is not None:
                     button.swap_colours()
+
+            # If no event and self.robot.memory has not been cleared
+            # move the robot
+            if self.robot.running:
+                self.robot.push_out_memory()
+                event = pygame.event.poll()
+
+                # Flip state to input if no more instructions to be done
+                if len(self.robot.memory) == self.robot.index:
+                    # Reset current instruction index
+                    self.robot.index = 0
+                    # Flip to input
+                    self.flip(False)
+
+                self.robot.move(event)
+                self.check_for_obstacle_collisions()
+                self.check_for_goal_collisions()
+                self.check_for_off_map()
 
         # If we get here, the main game loop has exited sommehow
         # Let's exit safely
@@ -560,12 +595,19 @@ class GameWindow(Thread):
             # push a win event
             pygame.event.post(pygame.event.Event(CustomEvent.RUN_WIN))
 
+    def flip(self, bool):
+        """Change the state of robot and buttons."""
+        self.robot.running = bool
+        self.create_buttons(True, bool)
+
     def fail_run(self):
         """Clear the event queue and push a RUN_FAIL event."""
         # clear any remaining events
         pygame.event.clear()
         # push a fail event
         pygame.event.post(pygame.event.Event(CustomEvent.RUN_FAIL))
+        # Flip state to input
+        self.flip(False)
 
     def check_for_obstacle_collisions(self):
         """Check if the BeeBot is currently on a Obstacle."""
@@ -618,6 +660,7 @@ class GameWindow(Thread):
 
     def handle_button_press(self, button):
         """Convert button press into game logic."""
+
         if button.text == 'Forward':
             self.store_movement('Forward')
 
@@ -640,8 +683,14 @@ class GameWindow(Thread):
             self.robot.memory = []
 
         if button.text == 'Go':
-            # Execute the instructions stored in the BeeBot
-            self.robot.push_out_memory()
+            # Flip state to running
+            self.flip(True)
+
+        if button.text == 'STOP':
+            # Reset current instruction index
+            self.robot.index = 0
+            # Flip state to input
+            self.flip(False)
 
     def handle_key_press(self, event):
         """Convert key press into game logic."""
@@ -672,4 +721,5 @@ class GameWindow(Thread):
         # if the event is the G key, push stored movement
         # events into the event queue.
         if event.key == ord('g') or event.key == ord('G'):
-            self.robot.push_out_memory()
+            # Flip state to running
+            self.flip(True)

--- a/src/GameWindow.py
+++ b/src/GameWindow.py
@@ -603,6 +603,10 @@ class GameWindow(Thread):
         # Reset the BeeBot memory pointer to the start of the instructions
         self.robot.index = 0
 
+        # Clear the queue incase movement events have already
+        # been pushed to the queue.
+        pygame.event.clear()
+
         self.buttons.get_named_button('Go').displayed = True
         self.buttons.get_named_button('Stop').displayed = False
 

--- a/test/test_beebot.py
+++ b/test/test_beebot.py
@@ -67,8 +67,10 @@ class TestBeeBot(unittest.TestCase):
             # Add all events to the BeeBot's memory
             for event in events:
                 self.test_robot.add_to_memory(event)
-            # Push the BeeBot's memory to the event loop
-            self.test_robot.push_out_memory()
+
+            # Push out all instructions
+            for event in events:
+                self.test_robot.push_out_memory()
 
             # Check the polled events match the events pushed
             for event in events:

--- a/test/test_default_scenario_run.py
+++ b/test/test_default_scenario_run.py
@@ -92,11 +92,7 @@ class TestRunSciBot(unittest.TestCase):
                         'Turn Right', 'Forward', 'Forward', 'Turn Right',
                         'Forward', 'Go']
 
-        # Simulate Button presses
-        for instruction in instructions:
-            self._press_button(instruction)
-
-        self._start_timed_logic(timeout_value=45)
+        self._start_timed_logic(timeout_value=60, instructions=instructions)
 
     def test_default_win_anti_clockwise(self):
         """Test the BeeBot can navigate the Default scenario."""
@@ -104,11 +100,7 @@ class TestRunSciBot(unittest.TestCase):
         instructions = ['Forward', 'Turn Left', 'Forward', 'Forward',
                         'Turn Left', 'Forward', 'Forward', 'Go']
 
-        # Simulate Button presses
-        for instruction in instructions:
-            self._press_button(instruction)
-
-        self._start_timed_logic(timeout_value=45)
+        self._start_timed_logic(timeout_value=60, instructions=instructions)
 
     # Patch so we can tell if fail_run is called
     @mock.patch('src.GameWindow.GameWindow.fail_run')
@@ -117,12 +109,9 @@ class TestRunSciBot(unittest.TestCase):
         # These Button presses will navigate the BeeBot into an Obstacle
         instructions = ['Turn Left', 'Forward', 'Go']
 
-        # Simulate Button presses
-        for instruction in instructions:
-            self._press_button(instruction)
-
         # This method should call fail_run given the above instructions
-        self._start_timed_logic(timeout_value=15, expected_to_timeout=True)
+        self._start_timed_logic(timeout_value=15, expected_to_timeout=True,
+                                instructions=instructions)
 
         # Assert fail_run was called exactly once
         self.assertEqual(mock_fail_run.call_count, 1)

--- a/test/test_default_scenario_run.py
+++ b/test/test_default_scenario_run.py
@@ -7,6 +7,7 @@ import mock
 import pygame
 
 from src.GameWindow import GameWindow, RenderingMode
+from src.Point import Point
 
 
 class TestRunSciBot(unittest.TestCase):
@@ -20,7 +21,8 @@ class TestRunSciBot(unittest.TestCase):
         # This list is used to generate 'Fake' Button press/release events
         buttons = [("Forward", 950, 420), ("Backward", 950, 680),
                    ("Turn Left", 820, 550), ("Turn Right", 1080, 550),
-                   ("Go", 950, 550), ("Reset", 820, 680), ("Clear", 1080, 680)]
+                   ("Go", 950, 550), ("Reset", 820, 680), ("Clear", 1080, 680),
+                   ("Stop", 950, 550)]
 
         # These dictionaries will store the events
         self.button_down_events = {}
@@ -64,6 +66,24 @@ class TestRunSciBot(unittest.TestCase):
         # Simulate Button presses
         for instruction in instructions:
             self._press_button(instruction)
+
+    def test_stop_button(self):
+        """Test that the Stop Button stops BeeBot movement."""
+        # These Button presses will move the BeeBot back exactly one space.
+        # As the Stop command will take effect once the BeeBot has processed
+        # the first Backward command, so it won't process the second.
+        instructions = ['Backward', 'Backward', 'Go', 'Stop']
+
+        self._start_timed_logic(timeout_value=15, expected_to_timeout=True,
+                                instructions=instructions)
+
+        position = Point(self.test_game_window.robot.logical_position.x,
+                         self.test_game_window.robot.logical_position.y)
+
+        # This is one space below the BeeBot's starting position
+        expected_position = Point(3, 2)
+
+        self.assertTrue(position.is_equal_to(expected_position))
 
     def test_default_win_clockwise(self):
         """Test the BeeBot can navigate the Default scenario."""

--- a/test/test_default_scenario_run.py
+++ b/test/test_default_scenario_run.py
@@ -59,6 +59,12 @@ class TestRunSciBot(unittest.TestCase):
         # Delay to simulate real user input
         time.sleep(1)
 
+    def _simulate_instructions(self, instructions):
+        time.sleep(1)
+        # Simulate Button presses
+        for instruction in instructions:
+            self._press_button(instruction)
+
     def test_default_win_clockwise(self):
         """Test the BeeBot can navigate the Default scenario."""
         # These Button presses will navigate the BeeBot to the Goals
@@ -110,17 +116,30 @@ class TestRunSciBot(unittest.TestCase):
         # After the timeout_value has been reached, stop the game logic
         self.test_game_window._logic_running = False
 
-    def _start_timed_logic(self, timeout_value=60, expected_to_timeout=False):
+    def _start_timed_logic(self, timeout_value=60, expected_to_timeout=False,
+                           instructions=None):
         """
         Start a GameWindow that will timeout after timeout_value.
 
         This method will trigger a test fail if timeout_value was reached
         and expected_to_timeout is False.
+
+        If provided, this method will simulate user input based on the
+        provided instructions.
         """
         # Start a timeout thread to catch case where
         # test fails but game loop does not exit
         timeout = threading.Thread(target=self._timeout, args=[timeout_value])
         timeout.start()
+
+        # If this method was passed instructions.
+        if instructions:
+            # Start a new thread to execute them.
+            # _simulate_instructions will wait a second to ensure the
+            # GameWindow is visible before simulating instructions
+            simulate = threading.Thread(target=self._simulate_instructions,
+                                        args=[instructions])
+            simulate.start()
 
         # Start the game logic
         self.test_game_window.start_logic(scenario='Default')


### PR DESCRIPTION
closes #13 

- Rework BeeBot memory pushing out to allow for the Stop Button to not get
  stuck behind the entire memory contents. Every GameLoop, if the BeeBot is
  'running' it will either move or push out an single instruction or stop moving. 
  This allows for the 'Stop' functionality to work.
- Buttons can now be part of a ButtonGroup but not displayed. This prevents
  'Runtime Error: dictionary changed size during iteration' problems.
- Add the ability to retrieve a specifc Button from the ButtonGroup by name, so
  it's display state can be toggled.
- Buttons can now only be clicked if displayed
- Adds start and stop movements methods to toggle the state of the BeeBot and
   Go/Stop Button 
- In order to get the stop button to work correct, the game loop ifs where
  changed to elifs and there order was changed so only one gets executed per
  game loop which helps with events being handled in the correct order and
  only 'one at a time'.
- Adds test cases for new functionality, using simulated mouse clicks. This
  led to some changes in the test case to support mouse clicks rather than
  events being processed.
- Also adds 'Stop' functionality via the keyboard